### PR TITLE
chore(security): patch transitive nanoid advisory

### DIFF
--- a/packages/ingestion/test/profile-materialization-scope.test.ts
+++ b/packages/ingestion/test/profile-materialization-scope.test.ts
@@ -27,7 +27,7 @@ const ACCEPTED_BYTES = {
   'packages/persistence/migrations/0004_repository_interviews.sql':
     '2cd18e7d92373215b2a540cdf12e32a7e949bfb01866616e8a44ad326e45bca0',
   'pnpm-lock.yaml':
-    '5268e9c506b73a83c8b32b4598c47693440fc4cb415887eef3f847e4938029c6',
+    '6d460bf8bc78278687759b99cb9369db62eab7d725984a151b80e6946e198599',
   'verification/retrieval-v1/profile-coverage.json':
     'e40137bc8b1e8b978a4e3008b876d1a284de0eca61daeda841c6492bdb24eaf8',
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,8 +1154,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2623,7 +2623,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2678,7 +2678,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,5 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 trustPolicy: no-downgrade
 trustLockfile: false
+minimumReleaseAgeExclude:
+  - nanoid@3.3.17


### PR DESCRIPTION
## Summary

- Patches the transitive Nanoid resolution associated with `GHSA-2v37-7h3g-55p8`, which was already present on `main`.
- Changes Nanoid only from `3.3.16` to `3.3.18`; Vitest, Vite, PostCSS, direct dependency versions, and all unrelated dependency versions remain unchanged.
- Adds the pnpm-supported minimum-release-age security exception for the minimum patched line: `nanoid@3.3.17`.
- Advances the existing lockfile-byte scope sentinel to the reviewed patched lock digest without weakening its logic.
- No product or evaluation semantics change.

## Audit and reconciliation history

1. The first `pnpm security:audit` wrapper invocation stopped before registry audit because the isolated worktree had not been hydrated (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`).
2. Frozen dependency hydration completed with zero tracked-byte mutation.
3. The second audit invocation reached the registry and reproduced `GHSA-2v37-7h3g-55p8` against Nanoid `3.3.16`.
4. One `pnpm audit --fix=update` invocation generated an over-broad diff and the task stopped.
5. Seven unrelated `workspace:0.0.0` to `workspace:*` manifest rewrites were rejected and restored byte-for-byte.
6. Removal of the explicit `allowBuilds: {}` policy was rejected.
7. The first lockfile-only reconciliation was blocked by committed `frozenLockfile: true`.
8. An independently authorized, command-scoped `--no-frozen-lockfile` reconciliation restored the original importer semantics; committed `frozenLockfile: true` remains unchanged.
9. Final dependency delta: Nanoid `3.3.16` → `3.3.18`.
10. `minimumReleaseAgeExclude` contains exactly `nanoid@3.3.17`.
11. `pnpm security:audit` now passes with no known vulnerabilities.
12. The historical lockfile-byte sentinel was advanced from the vulnerable lockfile SHA-256 to the reviewed patched lockfile SHA-256. Its structure, hashing logic, and fail-closed behavior remain unchanged.

## Scope

Exactly three files changed:

- `pnpm-lock.yaml`
- `pnpm-workspace.yaml`
- `packages/ingestion/test/profile-materialization-scope.test.ts`

No application, product implementation, evaluation authority, catalog, schema, or documentation semantics changed. This work is independent of Issue #23 and PR #22.

## Validation

- Focused scope sentinel: 4/4 tests passed
- Frozen install: passed with zero tracked mutation
- Dependency audit: passed; no known vulnerabilities
- Secret scan: passed
- Runtime, formatting, and repository-policy checks: passed
- Build, internal typecheck, and lint: passed
- `pnpm verify`: 115 test files / 1,802 tests passed
- Architecture: 847 modules / 2,810 dependencies, zero violations
- `git diff --check`: passed

Closes #24