### PR TITLE
fix(validation): reduce authority verification memory

### DIFF
--- a/packages/contracts/src/structural-validation.ts
+++ b/packages/contracts/src/structural-validation.ts
@@ -122,6 +122,22 @@ for (const branch of deterministicProfileFieldBranches) {
   deterministicProfileFieldBranchesById.set(fieldId, [...existing, branch]);
 }
 
+const deterministicProfileFieldCommonProperties = [
+  'fieldId',
+  'scope',
+  'stateReasonCode',
+  'stateRuleId',
+  'versionScope',
+  'sourceReferences',
+  'state',
+  'valueExtractionRuleId',
+] as const;
+const deterministicProfileFieldBranchShapes = [
+  [...deterministicProfileFieldCommonProperties, 'value'],
+  deterministicProfileFieldCommonProperties,
+  [...deterministicProfileFieldCommonProperties, 'claims'],
+].map((properties) => new Set<string>(properties));
+
 // The public schema remains the authority. Its private envelope validator
 // delegates profile items to the separately memoized profile validator so Ajv
 // does not inline the same large profile program into the authority program.
@@ -224,24 +240,10 @@ function createLazyCandidateProfileValidator(): LazyStructuralValidator<Determin
       deterministicCandidateProfileDigestSchema,
     );
     const fieldValidators = new Map<string, ValidateFunction>();
-    let fallbackFieldValidator: ValidateFunction | undefined;
-    const getFieldValidator = (field: unknown): ValidateFunction => {
-      const fieldId =
-        typeof field === 'object' && field !== null
-          ? (field as Record<string, unknown>)['fieldId']
-          : undefined;
-      if (typeof fieldId !== 'string') {
-        fallbackFieldValidator ??= ajv.compile(
-          deterministicProfileFieldRecordV1Schema,
-        );
-        return fallbackFieldValidator;
-      }
+    const getFieldValidator = (fieldId: string): ValidateFunction => {
       const branches = deterministicProfileFieldBranchesById.get(fieldId);
       if (branches === undefined) {
-        fallbackFieldValidator ??= ajv.compile(
-          deterministicProfileFieldRecordV1Schema,
-        );
-        return fallbackFieldValidator;
+        throw new Error('Deterministic profile field ID is not registered.');
       }
       const existing = fieldValidators.get(fieldId);
       if (existing !== undefined) {
@@ -257,16 +259,36 @@ function createLazyCandidateProfileValidator(): LazyStructuralValidator<Determin
         composite.errors = envelopeValidator.errors ?? null;
         return false;
       }
-      const fields = (value as DeterministicCandidateProfileV1).fields;
+      const fields = (value as { readonly fields: readonly unknown[] }).fields;
       for (const [index, field] of fields.entries()) {
-        const fieldValidator = getFieldValidator(field);
-        if (!fieldValidator(field)) {
-          composite.errors = (fieldValidator.errors ?? []).map((error) => ({
-            ...error,
-            instancePath: `/fields/${String(index)}${error.instancePath}`,
-          }));
-          return false;
+        const fieldId =
+          typeof field === 'object' && field !== null && !Array.isArray(field)
+            ? (field as Record<string, unknown>)['fieldId']
+            : undefined;
+        let fieldErrors: readonly ErrorObject[];
+        if (
+          typeof fieldId !== 'string' ||
+          !deterministicProfileFieldBranchesById.has(fieldId)
+        ) {
+          fieldErrors = malformedFieldDiscriminatorErrors(field);
+        } else {
+          const fieldValidator = getFieldValidator(fieldId);
+          if (fieldValidator(field)) {
+            continue;
+          }
+          fieldErrors = fieldValidator.errors ?? [];
+          if (nonmatchingFieldBranchReachesDiscriminator(field)) {
+            fieldErrors = [
+              ...fieldErrors,
+              compatibilityAjvError('const', '/fieldId'),
+            ];
+          }
         }
+        composite.errors = fieldErrors.map((error) => ({
+          ...error,
+          instancePath: `/fields/${String(index)}${error.instancePath}`,
+        }));
+        return false;
       }
       if (!digestValidator(value)) {
         composite.errors = digestValidator.errors ?? null;
@@ -278,6 +300,59 @@ function createLazyCandidateProfileValidator(): LazyStructuralValidator<Determin
     validator = composite;
     return validator;
   };
+}
+
+function malformedFieldDiscriminatorErrors(
+  field: unknown,
+): readonly ErrorObject[] {
+  if (typeof field !== 'object' || field === null || Array.isArray(field)) {
+    return [compatibilityAjvError('type', '')];
+  }
+  const errors: ErrorObject[] = [];
+  for (const properties of deterministicProfileFieldBranchShapes) {
+    if (
+      [...properties].some(
+        (property) => !Object.prototype.hasOwnProperty.call(field, property),
+      )
+    ) {
+      errors.push(compatibilityAjvError('required', ''));
+      continue;
+    }
+    if (Object.keys(field).some((property) => !properties.has(property))) {
+      errors.push(compatibilityAjvError('additionalProperties', ''));
+      continue;
+    }
+    errors.push(compatibilityAjvError('const', '/fieldId'));
+    if (typeof (field as Record<string, unknown>)['fieldId'] !== 'string') {
+      errors.push(compatibilityAjvError('type', '/fieldId'));
+    }
+  }
+  return errors;
+}
+
+function nonmatchingFieldBranchReachesDiscriminator(field: unknown): boolean {
+  if (typeof field !== 'object' || field === null || Array.isArray(field)) {
+    return false;
+  }
+  const keys = Object.keys(field);
+  return deterministicProfileFieldBranchShapes.some(
+    (properties) =>
+      [...properties].every((property) =>
+        Object.prototype.hasOwnProperty.call(field, property),
+      ) && keys.every((property) => properties.has(property)),
+  );
+}
+
+function compatibilityAjvError(
+  keyword: string,
+  instancePath: string,
+): ErrorObject {
+  return {
+    instancePath,
+    schemaPath: '',
+    keyword,
+    params: {},
+  } as ErrorObject;
 }
 
 export const capabilityRequestV1Validator =

--- a/packages/contracts/src/structural-validation.ts
+++ b/packages/contracts/src/structural-validation.ts
@@ -1,5 +1,6 @@
 import {
   Ajv2020,
+  type AnySchema,
   type ErrorObject,
   type ValidateFunction,
 } from 'ajv/dist/2020.js';
@@ -60,11 +61,12 @@ import {
 import {
   deterministicCandidateProfileAuthorityV1Schema,
   deterministicCandidateProfileV1Schema,
+  deterministicProfileFieldRecordV1Schema,
   type DeterministicCandidateProfileAuthorityV1,
   type DeterministicCandidateProfileV1,
 } from './deterministic-candidate-profile-schemas.ts';
 
-const ajv = new Ajv2020({
+const AJV_OPTIONS = {
   allErrors: false,
   coerceTypes: false,
   messages: false,
@@ -73,57 +75,276 @@ const ajv = new Ajv2020({
   useDefaults: false,
   validateFormats: false,
   verbose: false,
-});
+} as const;
 
-export const capabilityRequestV1Validator = ajv.compile<CapabilityRequestV1>(
-  capabilityRequestV1Schema,
-);
+const ajv = new Ajv2020(AJV_OPTIONS);
+
+const deterministicCandidateProfileEnvelopeSchema: AnySchema = {
+  ...deterministicCandidateProfileV1Schema,
+  $id: 'https://gitblocks.dev/schemas/contracts/deterministic-candidate-profile-envelope/1.0.0',
+  properties: {
+    ...deterministicCandidateProfileV1Schema.properties,
+    fields: {
+      ...deterministicCandidateProfileV1Schema.properties.fields,
+      items: true,
+    },
+    semanticProfileDigest: true,
+  },
+};
+
+const deterministicCandidateProfileDigestSchema: AnySchema = {
+  type: 'object',
+  required: ['semanticProfileDigest'],
+  properties: {
+    semanticProfileDigest:
+      deterministicCandidateProfileV1Schema.properties.semanticProfileDigest,
+  },
+};
+
+const deterministicProfileFieldBranches = (
+  deterministicProfileFieldRecordV1Schema as unknown as {
+    readonly anyOf: readonly AnySchema[];
+  }
+).anyOf;
+const deterministicProfileFieldBranchesById = new Map<
+  string,
+  readonly AnySchema[]
+>();
+for (const branch of deterministicProfileFieldBranches) {
+  const fieldId = (
+    branch as {
+      readonly properties: {
+        readonly fieldId: { readonly const: string };
+      };
+    }
+  ).properties.fieldId.const;
+  const existing = deterministicProfileFieldBranchesById.get(fieldId) ?? [];
+  deterministicProfileFieldBranchesById.set(fieldId, [...existing, branch]);
+}
+
+// The public schema remains the authority. Its private envelope validator
+// delegates profile items to the separately memoized profile validator so Ajv
+// does not inline the same large profile program into the authority program.
+const deterministicCandidateProfileAuthorityEnvelopeSchema: AnySchema = {
+  ...deterministicCandidateProfileAuthorityV1Schema,
+  $id: 'https://gitblocks.dev/schemas/contracts/deterministic-candidate-profile-authority-envelope/1.0.0',
+  properties: {
+    ...deterministicCandidateProfileAuthorityV1Schema.properties,
+    profiles: {
+      ...deterministicCandidateProfileAuthorityV1Schema.properties.profiles,
+      items: true,
+    },
+    semanticAuthorityDigest: true,
+  },
+};
+
+const deterministicCandidateProfileAuthorityDigestSchema: AnySchema = {
+  type: 'object',
+  required: ['semanticAuthorityDigest'],
+  properties: {
+    semanticAuthorityDigest:
+      deterministicCandidateProfileAuthorityV1Schema.properties
+        .semanticAuthorityDigest,
+  },
+};
+
+type LazyStructuralValidator<T> = () => ValidateFunction<T>;
+
+function createLazyStructuralValidator<T>(
+  schema: AnySchema,
+  prerequisites: readonly (() => unknown)[] = [],
+): LazyStructuralValidator<T> {
+  let validator: ValidateFunction<T> | undefined;
+  return () => {
+    for (const getPrerequisite of prerequisites) {
+      getPrerequisite();
+    }
+    validator ??= ajv.compile<T>(schema);
+    return validator;
+  };
+}
+
+function createLazyCandidateProfileAuthorityValidator(
+  getProfileValidator: LazyStructuralValidator<DeterministicCandidateProfileV1>,
+): LazyStructuralValidator<DeterministicCandidateProfileAuthorityV1> {
+  let validator:
+    ValidateFunction<DeterministicCandidateProfileAuthorityV1> | undefined;
+  return () => {
+    if (validator !== undefined) {
+      return validator;
+    }
+    const profileValidator = getProfileValidator();
+    const envelopeValidator =
+      ajv.compile<DeterministicCandidateProfileAuthorityV1>(
+        deterministicCandidateProfileAuthorityEnvelopeSchema,
+      );
+    const digestValidator =
+      ajv.compile<DeterministicCandidateProfileAuthorityV1>(
+        deterministicCandidateProfileAuthorityDigestSchema,
+      );
+    const composite = ((value: unknown) => {
+      composite.errors = null;
+      if (!envelopeValidator(value)) {
+        composite.errors = envelopeValidator.errors ?? null;
+        return false;
+      }
+      const profiles = (value as DeterministicCandidateProfileAuthorityV1)
+        .profiles;
+      for (const [index, profile] of profiles.entries()) {
+        if (!profileValidator(profile)) {
+          composite.errors = (profileValidator.errors ?? []).map((error) => ({
+            ...error,
+            instancePath: `/profiles/${String(index)}${error.instancePath}`,
+          }));
+          return false;
+        }
+      }
+      if (!digestValidator(value)) {
+        composite.errors = digestValidator.errors ?? null;
+        return false;
+      }
+      return true;
+    }) as unknown as ValidateFunction<DeterministicCandidateProfileAuthorityV1>;
+    composite.errors = null;
+    validator = composite;
+    return validator;
+  };
+}
+
+function createLazyCandidateProfileValidator(): LazyStructuralValidator<DeterministicCandidateProfileV1> {
+  let validator: ValidateFunction<DeterministicCandidateProfileV1> | undefined;
+  return () => {
+    if (validator !== undefined) {
+      return validator;
+    }
+    const envelopeValidator = ajv.compile<DeterministicCandidateProfileV1>(
+      deterministicCandidateProfileEnvelopeSchema,
+    );
+    const digestValidator = ajv.compile<DeterministicCandidateProfileV1>(
+      deterministicCandidateProfileDigestSchema,
+    );
+    const fieldValidators = new Map<string, ValidateFunction>();
+    let fallbackFieldValidator: ValidateFunction | undefined;
+    const getFieldValidator = (field: unknown): ValidateFunction => {
+      const fieldId =
+        typeof field === 'object' && field !== null
+          ? (field as Record<string, unknown>)['fieldId']
+          : undefined;
+      if (typeof fieldId !== 'string') {
+        fallbackFieldValidator ??= ajv.compile(
+          deterministicProfileFieldRecordV1Schema,
+        );
+        return fallbackFieldValidator;
+      }
+      const branches = deterministicProfileFieldBranchesById.get(fieldId);
+      if (branches === undefined) {
+        fallbackFieldValidator ??= ajv.compile(
+          deterministicProfileFieldRecordV1Schema,
+        );
+        return fallbackFieldValidator;
+      }
+      const existing = fieldValidators.get(fieldId);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const compiled = ajv.compile({ anyOf: branches });
+      fieldValidators.set(fieldId, compiled);
+      return compiled;
+    };
+    const composite = ((value: unknown) => {
+      composite.errors = null;
+      if (!envelopeValidator(value)) {
+        composite.errors = envelopeValidator.errors ?? null;
+        return false;
+      }
+      const fields = (value as DeterministicCandidateProfileV1).fields;
+      for (const [index, field] of fields.entries()) {
+        const fieldValidator = getFieldValidator(field);
+        if (!fieldValidator(field)) {
+          composite.errors = (fieldValidator.errors ?? []).map((error) => ({
+            ...error,
+            instancePath: `/fields/${String(index)}${error.instancePath}`,
+          }));
+          return false;
+        }
+      }
+      if (!digestValidator(value)) {
+        composite.errors = digestValidator.errors ?? null;
+        return false;
+      }
+      return true;
+    }) as unknown as ValidateFunction<DeterministicCandidateProfileV1>;
+    composite.errors = null;
+    validator = composite;
+    return validator;
+  };
+}
+
+export const capabilityRequestV1Validator =
+  createLazyStructuralValidator<CapabilityRequestV1>(capabilityRequestV1Schema);
 export const repositoryFingerprintV1Validator =
-  ajv.compile<RepositoryFingerprintV1>(repositoryFingerprintV1Schema);
-export const candidateDossierV1Validator = ajv.compile<CandidateDossierV1>(
-  candidateDossierV1Schema,
-);
+  createLazyStructuralValidator<RepositoryFingerprintV1>(
+    repositoryFingerprintV1Schema,
+  );
+export const candidateDossierV1Validator =
+  createLazyStructuralValidator<CandidateDossierV1>(candidateDossierV1Schema);
 export const fitAssessmentRequestV1Validator =
-  ajv.compile<FitAssessmentRequestV1>(fitAssessmentRequestV1Schema);
+  createLazyStructuralValidator<FitAssessmentRequestV1>(
+    fitAssessmentRequestV1Schema,
+  );
 export const fitAssessmentResponseV1Validator =
-  ajv.compile<FitAssessmentResponseV1>(fitAssessmentResponseV1Schema);
-export const errorEnvelopeV1Validator = ajv.compile<ErrorEnvelopeV1>(
-  errorEnvelopeV1Schema,
-);
-export const repositoryArtifactV1Validator = ajv.compile<RepositoryArtifactV1>(
-  repositoryArtifactV1Schema,
-);
+  createLazyStructuralValidator<FitAssessmentResponseV1>(
+    fitAssessmentResponseV1Schema,
+  );
+export const errorEnvelopeV1Validator =
+  createLazyStructuralValidator<ErrorEnvelopeV1>(errorEnvelopeV1Schema);
+export const repositoryArtifactV1Validator =
+  createLazyStructuralValidator<RepositoryArtifactV1>(
+    repositoryArtifactV1Schema,
+  );
 export const repositoryArtifactChunkV1Validator =
-  ajv.compile<RepositoryArtifactChunkV1>(repositoryArtifactChunkV1Schema);
+  createLazyStructuralValidator<RepositoryArtifactChunkV1>(
+    repositoryArtifactChunkV1Schema,
+  );
 export const repositoryArtifactSetV1Validator =
-  ajv.compile<RepositoryArtifactSetV1>(repositoryArtifactSetV1Schema);
+  createLazyStructuralValidator<RepositoryArtifactSetV1>(
+    repositoryArtifactSetV1Schema,
+  );
 export const repositoryInterviewRequestV1Validator =
-  ajv.compile<RepositoryInterviewRequestV1>(repositoryInterviewRequestV1Schema);
+  createLazyStructuralValidator<RepositoryInterviewRequestV1>(
+    repositoryInterviewRequestV1Schema,
+  );
 export const modelExecutionModelProfileV1Validator =
-  ajv.compile<ModelExecutionModelProfileV1>(modelExecutionModelProfileV1Schema);
-export const modelExecutionV1Validator = ajv.compile<ModelExecutionV1>(
-  modelExecutionV1Schema,
-);
+  createLazyStructuralValidator<ModelExecutionModelProfileV1>(
+    modelExecutionModelProfileV1Schema,
+  );
+export const modelExecutionV1Validator =
+  createLazyStructuralValidator<ModelExecutionV1>(modelExecutionV1Schema);
 export const repositoryInterviewV1Validator =
-  ajv.compile<RepositoryInterviewV1>(repositoryInterviewV1Schema);
+  createLazyStructuralValidator<RepositoryInterviewV1>(
+    repositoryInterviewV1Schema,
+  );
 export const capabilityTaxonomySourceV1Validator =
-  ajv.compile<CapabilityTaxonomySourceV1>(capabilityTaxonomySourceV1Schema);
-export const capabilityTaxonomyV1Validator = ajv.compile<CapabilityTaxonomyV1>(
-  capabilityTaxonomyV1Schema,
-);
+  createLazyStructuralValidator<CapabilityTaxonomySourceV1>(
+    capabilityTaxonomySourceV1Schema,
+  );
+export const capabilityTaxonomyV1Validator =
+  createLazyStructuralValidator<CapabilityTaxonomyV1>(
+    capabilityTaxonomyV1Schema,
+  );
 export const capabilityQueryInputV1Validator =
-  ajv.compile<CapabilityQueryInputV1>(capabilityQueryInputV1Schema);
+  createLazyStructuralValidator<CapabilityQueryInputV1>(
+    capabilityQueryInputV1Schema,
+  );
 export const capabilityQueryNormalizationResultV1Validator =
-  ajv.compile<CapabilityQueryNormalizationResultV1>(
+  createLazyStructuralValidator<CapabilityQueryNormalizationResultV1>(
     capabilityQueryNormalizationResultV1Schema,
   );
 export const deterministicCandidateProfileV1Validator =
-  ajv.compile<DeterministicCandidateProfileV1>(
-    deterministicCandidateProfileV1Schema,
-  );
+  createLazyCandidateProfileValidator();
 export const deterministicCandidateProfileAuthorityV1Validator =
-  ajv.compile<DeterministicCandidateProfileAuthorityV1>(
-    deterministicCandidateProfileAuthorityV1Schema,
+  createLazyCandidateProfileAuthorityValidator(
+    deterministicCandidateProfileV1Validator,
   );
 
 export type StructuralValidationResult<T> =
@@ -139,12 +360,13 @@ export type StructuralValidationResult<T> =
 
 export function structurallyValidate<T>(
   value: unknown,
-  validator: ValidateFunction<T>,
+  getValidator: LazyStructuralValidator<T>,
 ): StructuralValidationResult<T> {
   const preflightIssues = preflightContractValue(value);
   if (preflightIssues.length > 0) {
     return { ok: false, issues: preflightIssues };
   }
+  const validator = getValidator();
   try {
     if (validator(value)) {
       return { ok: true, value, issues: [] };
@@ -169,24 +391,25 @@ export function structurallyValidate<T>(
 
 export function structurallyValidateRepositoryArtifact<T>(
   value: unknown,
-  validator: ValidateFunction<T>,
+  getValidator: LazyStructuralValidator<T>,
 ): StructuralValidationResult<T> {
   return structurallyValidateWithPreflight(
     value,
-    validator,
+    getValidator,
     preflightRepositoryArtifactContractValue,
   );
 }
 
 function structurallyValidateWithPreflight<T>(
   value: unknown,
-  validator: ValidateFunction<T>,
+  getValidator: LazyStructuralValidator<T>,
   preflight: (input: unknown) => readonly ContractIssue[],
 ): StructuralValidationResult<T> {
   const preflightIssues = preflight(value);
   if (preflightIssues.length > 0) {
     return { ok: false, issues: preflightIssues };
   }
+  const validator = getValidator();
   try {
     if (validator(value)) {
       return { ok: true, value, issues: [] };

--- a/packages/contracts/test/deterministic-candidate-profile-contracts.test.ts
+++ b/packages/contracts/test/deterministic-candidate-profile-contracts.test.ts
@@ -580,6 +580,44 @@ describe('DeterministicCandidateProfileAuthorityV1', () => {
       semanticAuthorityDigest: '0'.repeat(64),
     });
   }, 30_000);
+
+  it('preserves structural diagnostic precedence across composed validation', () => {
+    const invalidProfile = authority.profiles.map((profile, index) =>
+      index === 0 ? { ...profile, contractVersion: '2.0.0' } : profile,
+    );
+    expect(
+      parseDeterministicCandidateProfileAuthorityV1({
+        ...authority,
+        profiles: invalidProfile,
+        semanticAuthorityDigest: 'x',
+      }),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        {
+          code: 'contract.version',
+          path: '/profiles/0/contractVersion',
+          message: 'Contract version is unsupported.',
+        },
+      ],
+    });
+    expect(
+      parseDeterministicCandidateProfileAuthorityV1({
+        ...authority,
+        catalogDigest: 'x',
+        profiles: invalidProfile,
+      }),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        {
+          code: 'contract.bounds',
+          path: '/catalogDigest',
+          message: 'Contract value is outside the allowed bounds.',
+        },
+      ],
+    });
+  });
 });
 
 function expectInvalid(value: unknown): void {

--- a/packages/contracts/test/deterministic-candidate-profile-contracts.test.ts
+++ b/packages/contracts/test/deterministic-candidate-profile-contracts.test.ts
@@ -124,6 +124,77 @@ describe('DeterministicCandidateProfileV1', () => {
     );
   });
 
+  it('preserves exact malformed-field structural diagnostics', () => {
+    const malformedCases: readonly [
+      string,
+      unknown,
+      readonly ExpectedContractIssue[],
+    ][] = [
+      [
+        'unknown field ID',
+        replaceField(validProfile, 'catalog-role-status', (field) => ({
+          ...field,
+          fieldId: 'unknown-field-id',
+        })),
+        [
+          additionalPropertyIssue('/fields/0'),
+          literalIssue('/fields/0/fieldId'),
+        ],
+      ],
+      [
+        'missing field ID',
+        replaceField(validProfile, 'catalog-role-status', (field) => {
+          const withoutFieldId = { ...field };
+          delete withoutFieldId['fieldId'];
+          return withoutFieldId;
+        }),
+        [requiredIssue('/fields/0')],
+      ],
+      [
+        'non-string field ID',
+        replaceField(validProfile, 'catalog-role-status', (field) => ({
+          ...field,
+          fieldId: 27,
+        })),
+        [
+          additionalPropertyIssue('/fields/0'),
+          literalIssue('/fields/0/fieldId'),
+          typeIssue('/fields/0/fieldId'),
+        ],
+      ],
+      [
+        'known field with malformed scope',
+        replaceField(validProfile, 'catalog-role-status', (field) => ({
+          ...field,
+          scope: 'invalid-scope',
+        })),
+        [
+          additionalPropertyIssue('/fields/0'),
+          literalIssue('/fields/0/fieldId'),
+          literalIssue('/fields/0/scope'),
+        ],
+      ],
+      [
+        'known field with malformed state value',
+        replaceField(validProfile, 'catalog-role-status', (field) => ({
+          ...field,
+          value: null,
+        })),
+        [
+          additionalPropertyIssue('/fields/0'),
+          literalIssue('/fields/0/fieldId'),
+          typeIssue('/fields/0/value'),
+        ],
+      ],
+    ];
+    for (const [name, value, issues] of malformedCases) {
+      expect(parseDeterministicCandidateProfileV1(value), name).toEqual({
+        ok: false,
+        issues,
+      });
+    }
+  });
+
   it('binds repository identity and package applicability to profile-owned fields', () => {
     expect(() =>
       createDeterministicCandidateProfileV1(
@@ -618,7 +689,68 @@ describe('DeterministicCandidateProfileAuthorityV1', () => {
       ],
     });
   });
+
+  it('preserves exact authority nesting for malformed profile fields', () => {
+    const profiles = authority.profiles.map((profile, index) =>
+      index === 0
+        ? (replaceField(profile, 'catalog-role-status', (field) => ({
+            ...field,
+            fieldId: 'unknown-field-id',
+          })) as DeterministicCandidateProfileV1)
+        : profile,
+    );
+    expect(
+      parseDeterministicCandidateProfileAuthorityV1({
+        ...authority,
+        profiles,
+      }),
+    ).toEqual({
+      ok: false,
+      issues: [
+        additionalPropertyIssue('/profiles/0/fields/0'),
+        literalIssue('/profiles/0/fields/0/fieldId'),
+      ],
+    });
+  });
 });
+
+interface ExpectedContractIssue {
+  readonly code: string;
+  readonly path: string;
+  readonly message: string;
+}
+
+function additionalPropertyIssue(path: string): ExpectedContractIssue {
+  return {
+    code: 'contract.additional-property',
+    path,
+    message: 'Contract value contains an additional field.',
+  };
+}
+
+function literalIssue(path: string): ExpectedContractIssue {
+  return {
+    code: 'contract.literal',
+    path,
+    message: 'Contract value does not match the required literal.',
+  };
+}
+
+function requiredIssue(path: string): ExpectedContractIssue {
+  return {
+    code: 'contract.required',
+    path,
+    message: 'Required contract field is missing.',
+  };
+}
+
+function typeIssue(path: string): ExpectedContractIssue {
+  return {
+    code: 'contract.type',
+    path,
+    message: 'Contract value has an invalid type.',
+  };
+}
 
 function expectInvalid(value: unknown): void {
   expect(parseDeterministicCandidateProfileV1(value).ok).toBe(false);

--- a/packages/ingestion/src/candidate-profile-projection.ts
+++ b/packages/ingestion/src/candidate-profile-projection.ts
@@ -26,6 +26,14 @@ import type {
   PublicCatalog,
 } from './types.ts';
 
+const PROFILE_FIELD_REGISTRY = getDeterministicProfileFieldRegistry();
+const PROFILE_FIELD_DEFINITIONS: ReadonlyMap<
+  DeterministicProfileFieldId,
+  (typeof PROFILE_FIELD_REGISTRY)[number]
+> = new Map(
+  PROFILE_FIELD_REGISTRY.map((definition) => [definition.fieldId, definition]),
+);
+
 export const CANDIDATE_PROFILE_COVERAGE_REPORT_VERSION =
   'deterministic-profile-coverage-report/1.0.0' as const;
 
@@ -176,9 +184,7 @@ function projectField(
   candidate: CatalogCandidate,
   fieldId: DeterministicProfileFieldId,
 ): object {
-  const definition = getDeterministicProfileFieldRegistry().find(
-    (entry) => entry.fieldId === fieldId,
-  );
+  const definition = PROFILE_FIELD_DEFINITIONS.get(fieldId);
   if (definition === undefined) {
     throw ingestionError('ingestion.internal-invariant');
   }
@@ -357,7 +363,7 @@ function buildCoverageReport(
 ): CandidateProfileCoverageReportV1 {
   const profiles =
     authority.profiles as unknown as readonly DeterministicCandidateProfile[];
-  const registry = getDeterministicProfileFieldRegistry();
+  const registry = PROFILE_FIELD_REGISTRY;
   const perField = registry.map((definition) => {
     const fields = profiles.map((profile) =>
       requireField(profile, definition.fieldId),

--- a/tools/evaluation-harness/src/retrieval/schema-registry.ts
+++ b/tools/evaluation-harness/src/retrieval/schema-registry.ts
@@ -57,7 +57,16 @@ export function createRetrievalSchemaRegistry(
   const definitionsV2 = loadSchema(schemaRoot, 'definitions-v2.schema.json');
   ajv.addSchema(definitionsV2);
   const validators = new Map<RetrievalSchemaName, ValidateFunction>();
-  for (const name of SCHEMA_NAMES) {
+  function getValidator(
+    name: RetrievalSchemaName,
+  ): ValidateFunction | undefined {
+    const existing = validators.get(name);
+    if (existing !== undefined) {
+      return existing;
+    }
+    if (!SCHEMA_NAMES.includes(name)) {
+      return undefined;
+    }
     const versioned =
       authorityVersion === 'v2' &&
       (name === 'baseline-report' ||
@@ -78,10 +87,11 @@ export function createRetrievalSchemaRegistry(
       throw new Error('Retrieval evaluation schema could not be registered.');
     }
     validators.set(name, validator);
+    return validator;
   }
   return {
     validate(name, value) {
-      const validator = validators.get(name);
+      const validator = getValidator(name);
       if (validator === undefined) {
         return [diagnostic('retrieval.schema.unknown', '', 'Unknown schema.')];
       }

--- a/tools/evaluation-harness/test/retrieval-architecture.test.ts
+++ b/tools/evaluation-harness/test/retrieval-architecture.test.ts
@@ -173,7 +173,7 @@ describe('retrieval evaluation architecture', () => {
       'verification/retrieval-v1/profile-coverage.json':
         'e40137bc8b1e8b978a4e3008b876d1a284de0eca61daeda841c6492bdb24eaf8',
       'packages/ingestion/src/candidate-profile-projection.ts':
-        'b7a8146372bb0077b3591d03c2cd5a29cd77b5b101ac570b89f50e329b8dbf68',
+        '4dd72b224967f5bb886af51c9ca4bb7f71ba50a5608b781d26b261a30cda738f',
       'packages/ingestion/src/profile.ts':
         '735ae75a1509c9fa909bd1a97ff3d3be06bb628d4197561984924132290e92d9',
       'packages/domain/src/deterministic-candidate-profile.ts':

--- a/tools/evaluation-harness/test/retrieval-query-blindness.test.ts
+++ b/tools/evaluation-harness/test/retrieval-query-blindness.test.ts
@@ -86,6 +86,18 @@ describe('retrieval query blindness', () => {
     }
   });
 
+  it.each(['v1', 'v2'] as const)(
+    'preserves repeated query validation on one %s registry',
+    (authorityVersion) => {
+      const registry = createRetrievalSchemaRegistry(root, authorityVersion);
+      expect(registry.validate('query', query)).toEqual([]);
+      const invalid = { ...query, hiddenAnswer: true };
+      const first = registry.validate('query', invalid);
+      expect(first).not.toEqual([]);
+      expect(registry.validate('query', invalid)).toEqual(first);
+    },
+  );
+
   it('uses the accepted closed query-input parser', () => {
     for (const forbidden of [
       { arbitraryUrl: 'https://example.invalid' },


### PR DESCRIPTION
Refs #28

## Scope

This is Issue #28A only.

It does not yet claim hosted-CI reliability. It is the measured memory foundation for a later shared retrieval-verification context.

PR #29 remains a frozen failed experiment and will be superseded only after the replacement architecture is independently accepted.

## Primitive corrections

- Contract structural validators now compile on first use and memoize one validator per closed schema slot; the existing Ajv options, preflight, failures, and diagnostics remain intact.
- Deterministic candidate-profile projection acquires one detached immutable 27-field registry snapshot and reuses an immutable lookup instead of cloning/freezing the registry once per projected field.
- Each retrieval schema registry now loads and compiles a named schema only on first use, then memoizes it within that registry. No global registry or shared verification context was introduced.

## Measured resource change

Identical macOS `/usr/bin/time -l -p` methodology was used against the authenticated Issue #28 diagnostic baseline.

| Command | Before peak RSS | After peak RSS | Reduction | After wall |
|---|---:|---:|---:|---:|
| retrieval validate | 20.912 GiB | 0.479 GiB | 97.71% | 1.68 s |
| retrieval validate-v2 | 20.846 GiB | 0.440 GiB | 97.89% | 1.67 s |
| retrieval verify | 23.039 GiB | 0.479 GiB | 97.92% | 5.19 s |
| retrieval verify-v2 | 22.946 GiB | 0.477 GiB | 97.92% | 5.21 s |
| gates-validate-v2 | 23.543 GiB | 0.450 GiB | 98.09% | 2.18 s |
| candidate-profile validation | 23.511 GiB | 0.424 GiB | 98.20% | 1.08 s |
| Contracts/Domain shard | 12.600 GiB | 0.767 GiB | 93.91% | 3.55 s |
| Persistence/Ingestion shard | 11.709 GiB | 0.463 GiB | 96.04% | 9.73 s |
| Evaluation Harness shard | 23.147 GiB | 0.702 GiB | 96.97% | 12.34 s |

All three 28A acceptance-critical commands are comfortably below the 6-GiB target. The heavier commands and shards also exceed the required 50% reduction.

## Semantic and deterministic validation

- Focused subsystem suites passed.
- `pnpm runtime:check`, format, build, internal typecheck, lint, repository policy, architecture, and `git diff --check` passed.
- `pnpm verify`: 117/117 test files, 1814/1814 tests, zero failures; architecture 853 modules, 2864 dependencies, zero violations.
- `pnpm security:audit`: no known vulnerabilities.
- Candidate-profile authority and coverage files are byte-identical to main; all v1/v2 corpus, baseline, review, saturation, and gate semantic digests remain unchanged.
- The deliberate independent baseline generations, reverse-order generation, repeated scoring, fresh-process corpus validation, committed-byte comparisons, and gate reconstruction remain present.

## Boundaries

- No CI/workflow or repository CI-policy change.
- No dependency, lockfile, workspace-policy, schema, product retrieval, evaluation authority, gold, scorer, baseline, or gate change.
- No RetrievalVerificationContext or consolidated verifier yet.
- Phase 9 and Milestone 4 remain untouched.

## Malformed-input compatibility hardening

- Frozen differential corpus: 197 deterministic cases across all 27 field IDs plus profile, authority, discriminator, and non-object mutations.
- Pre-fix comparison: 86 exact matches and 111 mismatches. The mismatches were nonmatching-field diagnostic contributions for wrong scope, invalid state/extraction/source, and malformed known-state payloads.
- Post-fix comparison: 197/197 exact matches (100%) against accepted main, including complete issue ordering.
- The full `ajv.compile(deterministicProfileFieldRecordV1Schema)` fallback is removed. Malformed discriminators use a finite, allocation-bounded branch-envelope projection; recognized IDs retain their memoized field-only branches.
- Fresh-process hostile full-authority peaks: unknown ID 140.6 MiB; missing ID 140.1 MiB; numeric ID 140.4 MiB; null field 139.7 MiB; recognized ID with wrong scope 141.7 MiB. Every result exactly matched the accepted-main diagnostic oracle.
- Reconfirmed happy-path peaks: candidate profile 0.403 GiB; validate 0.486 GiB; validate-v2 0.448 GiB; verify 0.482 GiB; verify-v2 0.486 GiB; gates-validate-v2 0.509 GiB.
- Focused contract tests passed. Full `pnpm verify` passed 117/117 files and 1816/1816 tests; architecture remained 853 modules, 2864 dependencies, zero violations. Dependency audit found no known vulnerabilities.
- No public schema, authority, evaluation, CI, dependency, or product behavior changed.

## Independent acceptance

Issue #28 replacement architecture independently accepted.

The hardened implementation preserved accepted contract diagnostics, bounded hostile malformed inputs, retained all authority identities, reduced the measured heavy validation footprint to sub-GiB operation, and completed the original hosted CI topology successfully on two consecutive natural runs without reruns.

Issue #28B / RetrievalVerificationContext is not required for reliability.